### PR TITLE
Fixed sort on Chrome, and made broken cross-browser sort in Chrome a problem-user behaviour

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2583,7 +2583,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2998,7 +2999,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3054,6 +3056,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3097,12 +3100,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/src/js/components/checkout-summary.js
+++ b/src/js/components/checkout-summary.js
@@ -69,7 +69,7 @@ class SummaryItem extends Component {
         orderTotal = orderTotal + InventoryData.ITEMS[contents[curItem]].price;
         if (Credentials.isProblemUser()) {
           // double up for the problem user
-          orderTotal = orderTotal + InventoryData.ITEMS[curItem].price;
+          orderTotal = orderTotal + InventoryData.ITEMS[contents[curItem]].price;
         }
       }
 

--- a/src/js/components/inventory-list.js
+++ b/src/js/components/inventory-list.js
@@ -101,6 +101,7 @@ class InventoryList extends Component {
         inventoryList: InventoryData.ITEMS_NAME_AZ
     };
 
+    this.sortByOption = this.sortByOption.bind(this);
     this.sortNameAZ = this.sortNameAZ.bind(this);
     this.sortNameZA = this.sortNameZA.bind(this);
     this.sortPriceLoHi = this.sortPriceLoHi.bind(this);
@@ -114,25 +115,86 @@ class InventoryList extends Component {
     }
   }
 
+  sortByOption(event) {
+
+    console.log(event);
+
+    if (Credentials.isProblemUser()) {
+      // Bail out now if we're problem user so that we have a behaviour which is broken in Chrome only for sort.
+      // select option onclick is not supported in Chrome but works in IE and FF
+      return;
+    }
+
+    switch (event.target.value) {
+      case "az":
+
+        this.setState({
+          inventoryList: InventoryData.ITEMS_NAME_AZ
+        });
+        break;
+
+      case "za":
+
+        this.setState({
+          inventoryList: InventoryData.ITEMS_NAME_ZA
+        });
+        break;
+
+      case "hilo":
+
+        this.setState({
+          inventoryList: InventoryData.ITEMS_PRICE_HILO
+        });
+        break;
+
+      case "lohi":
+
+        this.setState({
+          inventoryList: InventoryData.ITEMS_PRICE_LOHI
+        });
+        break;
+    }
+  }
+
   sortNameAZ() {
+    if (!Credentials.isProblemUser()) {
+      // Bail out now if we're not problem user - the select onchange will handle the sort
+      return;
+    }
+
     this.setState({
       inventoryList: InventoryData.ITEMS_NAME_AZ
     });
   }
 
   sortNameZA() {
+    if (!Credentials.isProblemUser()) {
+      // Bail out now if we're not problem user - the select onchange will handle the sort
+      return;
+    }
+
     this.setState({
       inventoryList: InventoryData.ITEMS_NAME_ZA
     });
   }
 
   sortPriceLoHi() {
+    if (!Credentials.isProblemUser()) {
+      // Bail out now if we're not problem user - the select onchange will handle the sort
+      return;
+    }
+
     this.setState({
       inventoryList: InventoryData.ITEMS_PRICE_LOHI
     });
   }
 
   sortPriceHiLo() {
+    if (!Credentials.isProblemUser()) {
+      // Bail out now if we're not problem user - the select onchange will handle the sort
+      return;
+    }
+
     this.setState({
       inventoryList: InventoryData.ITEMS_PRICE_HILO
     });
@@ -151,11 +213,11 @@ class InventoryList extends Component {
         <div id="searchbox_container"></div>
         <div id="inventory_filter_container">
           <div class="product_label">Products</div>
-          <select class="product_sort_container">
-            <option onClick={this.sortNameAZ}>Name (A to Z)</option>
-            <option onClick={this.sortNameZA}>Name (Z to A)</option>
-            <option onClick={this.sortPriceLoHi}>Price (low to high)</option>
-            <option onClick={this.sortPriceHiLo}>Price (high to low)</option>
+          <select onChange={this.sortByOption} class="product_sort_container">
+            <option value="az" onClick={this.sortNameAZ}>Name (A to Z)</option>
+            <option value="za" onClick={this.sortNameZA}>Name (Z to A)</option>
+            <option value="lohi" onClick={this.sortPriceLoHi}>Price (low to high)</option>
+            <option value="hilo" onClick={this.sortPriceHiLo}>Price (high to low)</option>
           </select>
         </div>
       </div>


### PR DESCRIPTION
* Chrome does not support select option onclick, so we need to use select onchange to make sort work
* If problem user is signed in, the old behaviour with select option onclick is restored so that sort will
  work in Firefox and IE but not in Chrome
* Also fixed a price calculation bug on the checkout page