### PR TITLE
fix: fix urlSearchParams error for IE11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1832,9 +1832,9 @@
       }
     },
     "acorn": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.0.tgz",
-      "integrity": "sha512-gac8OEcQ2Li1dxIEWGZzsp2BitJxwkwcOm0zHAJLcPJaVvm58FRnk6RkuLRpU1EujipU2ZFODv2P9DLMfnV8mw==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
+      "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
       "dev": true
     },
     "ajv": {
@@ -6372,9 +6372,9 @@
       "dev": true
     },
     "kind-of": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "dev": true
     },
     "lazystream": {
@@ -9808,6 +9808,11 @@
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
       }
+    },
+    "url-search-params-polyfill": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/url-search-params-polyfill/-/url-search-params-polyfill-8.0.0.tgz",
+      "integrity": "sha512-X4BTaEq1UMz9bTbMKQ6r+CippkKBsFWHiP9wycQc7aHH2Ml/Iieuo44+GJDb77pfP71bONYA/nUd4iokYAxVRQ=="
     },
     "use": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "@fortawesome/react-fontawesome": "0.1.3",
     "react": "16.6.0",
     "react-burger-menu": "2.5.4",
-    "react-dom": "16.6.0"
+    "react-dom": "16.6.0",
+    "url-search-params-polyfill": "^8.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.3",

--- a/src/js/components/inventory-item.js
+++ b/src/js/components/inventory-item.js
@@ -1,3 +1,5 @@
+// Needed for IE 11
+import 'url-search-params-polyfill';
 import React, { Component } from 'react';
 import ReactDOM from 'react-dom';
 import { InventoryData } from '../data/inventory-data.js';
@@ -27,11 +29,10 @@ class InventoryItem extends Component {
           4 T 1.`,
           image_url: './img/sl-404.jpg',
           price: '√-1'
-          
       };
     }
     this.item.id = inventoryId;
-    
+
     this.state = {
       // Set our initial state now
       itemInCart: ShoppingCart.isItemInCart(inventoryId)
@@ -73,7 +74,7 @@ class InventoryItem extends Component {
   render () {
 
     var cartButton;
-    
+
     if (this.state.itemInCart) {
       cartButton = <button className="btn_secondary btn_inventory" onClick={() => this.removeFromCart(this.item.id)}>REMOVE</button>;
     } else {


### PR DESCRIPTION
This fixes an issue in IE11 with URLSearchParams. I've added a polyfill

This was happening in IE 11 before the fix

![image](https://user-images.githubusercontent.com/11979740/76706050-f9569880-66e4-11ea-9c99-3d18dcc615a2.png)


And this after the fix

![image](https://user-images.githubusercontent.com/11979740/76706057-08d5e180-66e5-11ea-8f16-7a70519e5891.png)


Can we merge this and push to https://www.saucedemo.com?