### PR TITLE
add a copyright link at the bottom of the login page

### DIFF
--- a/src/pages/Login.css
+++ b/src/pages/Login.css
@@ -80,4 +80,7 @@
     min-height: 260px;
     min-width: 300px;
   }
+  .copyright {
+    text-align: center;
+  }
 }

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -139,6 +139,9 @@ function Login(props) {
           </div>
         </div>
       </div>
+      <div className="copyright">
+        <a href="https://www.saucelabs.com" >(c) Sauce Labs</a>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
I want to be able to show off Selector Strategies for Link text from Swag Labs login page.
Let me know if this isn't the right way to do it for this app.