### PR TITLE
Add Dynamic Catalog submenu with lazy-load, spinner, and slider demo pages

### DIFF
--- a/src/components/DrawerMenu.css
+++ b/src/components/DrawerMenu.css
@@ -67,3 +67,22 @@
 .visual_failure {
   transform: rotate(3deg);
 }
+
+.submenu-chevron {
+  display: inline-block;
+  margin-left: 6px;
+  border: solid #18583a;
+  border-width: 0 2px 2px 0;
+  padding: 3px;
+  transform: rotate(45deg);
+  transition: transform 0.2s ease;
+}
+
+.submenu-chevron.open {
+  transform: rotate(-135deg);
+}
+
+.submenu-item {
+  padding-left: 20px;
+  font-size: 14px;
+}

--- a/src/components/DrawerMenu.jsx
+++ b/src/components/DrawerMenu.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { withRouter } from "../utils/withRouter";
 import PropTypes from "prop-types";
 import { slide as Menu } from "react-burger-menu";
@@ -16,6 +16,7 @@ import menuIconSvg from "../assets/svg/menu3x.svg";
 import "./DrawerMenu.css";
 
 const DrawerMenu = ({ history }) => {
+  const [isDynamicCatalogOpen, setIsDynamicCatalogOpen] = useState(false);
   const resetStorage = () => {
     // Wipe out our shopping cart now
     ShoppingCart.resetCart();
@@ -64,6 +65,68 @@ const DrawerMenu = ({ history }) => {
       >
         All Items
       </a>
+      <a
+        id="dynamic_catalog_sidebar_link"
+        className="menu-item"
+        href="#"
+        onClick={(evt) => {
+          evt.preventDefault();
+          setIsDynamicCatalogOpen((open) => !open);
+        }}
+        data-test="dynamic-catalog-sidebar-link"
+        role="button"
+        aria-expanded={isDynamicCatalogOpen}
+        aria-controls="dynamic_catalog_submenu"
+      >
+        Dynamic Catalog
+        <span
+          className={`submenu-chevron${isDynamicCatalogOpen ? " open" : ""}`}
+          aria-hidden="true"
+        />
+      </a>
+      {isDynamicCatalogOpen && (
+        <div id="dynamic_catalog_submenu" data-test="dynamic-catalog-submenu">
+          <a
+            id="dynamic_catalog_lazy_load_link"
+            className="menu-item submenu-item"
+            href="#"
+            onClick={(evt) => {
+              evt.preventDefault();
+              history.push(ROUTES.DYNAMIC_CATALOG_LAZY_LOAD);
+            }}
+            data-test="dynamic-catalog-lazy-load-link"
+            role="button"
+          >
+            Lazy Load
+          </a>
+          <a
+            id="dynamic_catalog_spinner_link"
+            className="menu-item submenu-item"
+            href="#"
+            onClick={(evt) => {
+              evt.preventDefault();
+              history.push(ROUTES.DYNAMIC_CATALOG_SPINNER);
+            }}
+            data-test="dynamic-catalog-spinner-link"
+            role="button"
+          >
+            Spinner
+          </a>
+          <a
+            id="dynamic_catalog_slider_link"
+            className="menu-item submenu-item"
+            href="#"
+            onClick={(evt) => {
+              evt.preventDefault();
+              history.push(ROUTES.DYNAMIC_CATALOG_SLIDER);
+            }}
+            data-test="dynamic-catalog-slider-link"
+            role="button"
+          >
+            Slider
+          </a>
+        </div>
+      )}
       <a
         id="about_sidebar_link"
         className="menu-item"

--- a/src/components/DynamicCatalogItemCard.css
+++ b/src/components/DynamicCatalogItemCard.css
@@ -1,0 +1,42 @@
+.dynamic_catalog_card {
+  border: 1px solid #ededed;
+  background: #fff;
+  box-sizing: border-box;
+  border-radius: 8px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.dynamic_catalog_card_img {
+  width: 100%;
+  height: 200px;
+  object-fit: cover;
+}
+
+.dynamic_catalog_card_name {
+  font-family: "DM Mono", sans-serif;
+  font-size: 16px;
+  font-weight: 500;
+  color: #18583a;
+  padding: 12px 16px 0;
+}
+
+.dynamic_catalog_card_price {
+  font-family: "DM Mono", sans-serif;
+  font-size: 16px;
+  font-weight: 500;
+  color: #132322;
+  padding: 8px 16px 16px;
+}
+
+.dynamic_catalog_card_placeholder {
+  height: 200px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #f4f4f4;
+  color: #767676;
+  font-family: "DM Sans", sans-serif;
+  font-size: 14px;
+}

--- a/src/components/DynamicCatalogItemCard.jsx
+++ b/src/components/DynamicCatalogItemCard.jsx
@@ -1,0 +1,68 @@
+import React, { forwardRef } from "react";
+import PropTypes from "prop-types";
+import getImage from "../utils/imageLoader";
+import "./DynamicCatalogItemCard.css";
+
+const DynamicCatalogItemCard = forwardRef(
+  ({ item, isLoaded = true, testId }, ref) => {
+    const imgSrc = getImage(item.image_url);
+
+    return (
+      <div ref={ref} className="dynamic_catalog_card" data-test={testId}>
+        {isLoaded ? (
+          <>
+            <img
+              alt={item.name}
+              className="dynamic_catalog_card_img"
+              src={imgSrc}
+              data-test={`${testId}-img`}
+            />
+            <div
+              className="dynamic_catalog_card_name"
+              data-test={`${testId}-name`}
+            >
+              {item.name}
+            </div>
+            <div
+              className="dynamic_catalog_card_price"
+              data-test={`${testId}-price`}
+            >
+              ${item.price}
+            </div>
+          </>
+        ) : (
+          <div
+            className="dynamic_catalog_card_placeholder"
+            data-test={`${testId}-placeholder`}
+          >
+            Loading…
+          </div>
+        )}
+      </div>
+    );
+  },
+);
+
+DynamicCatalogItemCard.displayName = "DynamicCatalogItemCard";
+
+DynamicCatalogItemCard.propTypes = {
+  /**
+   * The item to render
+   */
+  item: PropTypes.shape({
+    id: PropTypes.number.isRequired,
+    name: PropTypes.string.isRequired,
+    price: PropTypes.number.isRequired,
+    image_url: PropTypes.string.isRequired,
+  }).isRequired,
+  /**
+   * Whether the item content is loaded, or a placeholder should show instead
+   */
+  isLoaded: PropTypes.bool,
+  /**
+   * The base data-test id for this card
+   */
+  testId: PropTypes.string.isRequired,
+};
+
+export default DynamicCatalogItemCard;

--- a/src/components/LazyCatalogCard.jsx
+++ b/src/components/LazyCatalogCard.jsx
@@ -1,0 +1,52 @@
+import React, { useEffect, useRef, useState } from "react";
+import PropTypes from "prop-types";
+import DynamicCatalogItemCard from "./DynamicCatalogItemCard";
+
+const LazyCatalogCard = ({ item, testId }) => {
+  const [isLoaded, setIsLoaded] = useState(false);
+  const nodeRef = useRef(null);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            setIsLoaded(true);
+            observer.unobserve(entry.target);
+          }
+        });
+      },
+      { threshold: 0.1 },
+    );
+
+    observer.observe(nodeRef.current);
+
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <DynamicCatalogItemCard
+      ref={nodeRef}
+      item={item}
+      isLoaded={isLoaded}
+      testId={testId}
+    />
+  );
+};
+
+LazyCatalogCard.propTypes = {
+  /**
+   * The item to render once it scrolls into view
+   */
+  item: PropTypes.shape({
+    name: PropTypes.string.isRequired,
+    price: PropTypes.number.isRequired,
+    image_url: PropTypes.string.isRequired,
+  }).isRequired,
+  /**
+   * The base data-test id for this card
+   */
+  testId: PropTypes.string.isRequired,
+};
+
+export default LazyCatalogCard;

--- a/src/components/__tests__/DrawerMenu.tests.js
+++ b/src/components/__tests__/DrawerMenu.tests.js
@@ -65,4 +65,63 @@ describe("DrawerMenu", () => {
     });
     expect(ShoppingCart.resetCart).toHaveBeenCalledTimes(1);
   });
+
+  it("should toggle the dynamic catalog submenu open and closed", () => {
+    const { getByTestId, queryByTestId } = render(
+      <DrawerMenu.WrappedComponent {...props} />,
+    );
+    expect(queryByTestId("dynamic-catalog-submenu")).not.toBeInTheDocument();
+
+    fireEvent.click(getByTestId("dynamic-catalog-sidebar-link"), {
+      preventDefault() {},
+    });
+    expect(getByTestId("dynamic-catalog-submenu")).toBeInTheDocument();
+    expect(
+      getByTestId("dynamic-catalog-sidebar-link").getAttribute("aria-expanded"),
+    ).toEqual("true");
+
+    fireEvent.click(getByTestId("dynamic-catalog-sidebar-link"), {
+      preventDefault() {},
+    });
+    expect(queryByTestId("dynamic-catalog-submenu")).not.toBeInTheDocument();
+  });
+
+  it("should be able to redirect to the lazy load page when clicking on the submenu link", () => {
+    const { getByTestId } = render(<DrawerMenu.WrappedComponent {...props} />);
+    fireEvent.click(getByTestId("dynamic-catalog-sidebar-link"), {
+      preventDefault() {},
+    });
+    fireEvent.click(getByTestId("dynamic-catalog-lazy-load-link"), {
+      preventDefault() {},
+    });
+    expect(props.history.push).toHaveBeenCalledWith(
+      "/dynamic-catalog-lazy-load.html",
+    );
+  });
+
+  it("should be able to redirect to the spinner page when clicking on the submenu link", () => {
+    const { getByTestId } = render(<DrawerMenu.WrappedComponent {...props} />);
+    fireEvent.click(getByTestId("dynamic-catalog-sidebar-link"), {
+      preventDefault() {},
+    });
+    fireEvent.click(getByTestId("dynamic-catalog-spinner-link"), {
+      preventDefault() {},
+    });
+    expect(props.history.push).toHaveBeenCalledWith(
+      "/dynamic-catalog-spinner.html",
+    );
+  });
+
+  it("should be able to redirect to the slider page when clicking on the submenu link", () => {
+    const { getByTestId } = render(<DrawerMenu.WrappedComponent {...props} />);
+    fireEvent.click(getByTestId("dynamic-catalog-sidebar-link"), {
+      preventDefault() {},
+    });
+    fireEvent.click(getByTestId("dynamic-catalog-slider-link"), {
+      preventDefault() {},
+    });
+    expect(props.history.push).toHaveBeenCalledWith(
+      "/dynamic-catalog-slider.html",
+    );
+  });
 });

--- a/src/components/__tests__/DynamicCatalogItemCard.tests.js
+++ b/src/components/__tests__/DynamicCatalogItemCard.tests.js
@@ -1,0 +1,35 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import DynamicCatalogItemCard from "../DynamicCatalogItemCard";
+
+const item = {
+  id: 0,
+  name: "Sauce Labs Bike Light",
+  price: 9.99,
+  image_url: "bike-light-1200x1500.jpg",
+};
+
+describe("DynamicCatalogItemCard", () => {
+  it("should render the item content when loaded", () => {
+    const { getByTestId } = render(
+      <DynamicCatalogItemCard item={item} testId="card-0" />,
+    );
+    expect(getByTestId("card-0-name")).toHaveTextContent(item.name);
+    expect(getByTestId("card-0-price")).toHaveTextContent("$9.99");
+    expect(getByTestId("card-0-img")).toBeInTheDocument();
+  });
+
+  it("should render a placeholder when not loaded", () => {
+    const { getByTestId, queryByTestId } = render(
+      <DynamicCatalogItemCard item={item} isLoaded={false} testId="card-0" />,
+    );
+    expect(getByTestId("card-0-placeholder")).toBeInTheDocument();
+    expect(queryByTestId("card-0-name")).not.toBeInTheDocument();
+  });
+
+  it("should forward a ref to the root element", () => {
+    const ref = React.createRef();
+    render(<DynamicCatalogItemCard ref={ref} item={item} testId="card-0" />);
+    expect(ref.current).toBeInstanceOf(HTMLElement);
+  });
+});

--- a/src/components/__tests__/LazyCatalogCard.tests.js
+++ b/src/components/__tests__/LazyCatalogCard.tests.js
@@ -1,0 +1,88 @@
+import React from "react";
+import { act, render } from "@testing-library/react";
+import LazyCatalogCard from "../LazyCatalogCard";
+
+class MockIntersectionObserver {
+  constructor(callback) {
+    this.callback = callback;
+    this.observed = [];
+    MockIntersectionObserver.instances.push(this);
+  }
+
+  observe(target) {
+    this.observed.push(target);
+  }
+
+  unobserve(target) {
+    this.observed = this.observed.filter((node) => node !== target);
+  }
+
+  disconnect() {
+    this.observed = [];
+  }
+}
+MockIntersectionObserver.instances = [];
+
+const item = {
+  id: 0,
+  name: "Sauce Labs Bike Light",
+  price: 9.99,
+  image_url: "bike-light-1200x1500.jpg",
+};
+
+describe("LazyCatalogCard", () => {
+  const realIntersectionObserver = global.IntersectionObserver;
+
+  beforeEach(() => {
+    MockIntersectionObserver.instances = [];
+    global.IntersectionObserver = MockIntersectionObserver;
+  });
+
+  afterEach(() => {
+    global.IntersectionObserver = realIntersectionObserver;
+  });
+
+  it("should render a placeholder before it intersects", () => {
+    const { getByTestId } = render(
+      <LazyCatalogCard item={item} testId="card-0" />,
+    );
+    expect(getByTestId("card-0-placeholder")).toBeInTheDocument();
+  });
+
+  it("should load and unobserve once it intersects", () => {
+    const { getByTestId } = render(
+      <LazyCatalogCard item={item} testId="card-0" />,
+    );
+    const observer = MockIntersectionObserver.instances[0];
+    const [target] = observer.observed;
+
+    act(() => {
+      observer.callback([{ target, isIntersecting: true }]);
+    });
+
+    expect(getByTestId("card-0-name")).toBeInTheDocument();
+    expect(observer.observed).not.toContain(target);
+  });
+
+  it("should ignore entries that are not intersecting", () => {
+    const { queryByTestId } = render(
+      <LazyCatalogCard item={item} testId="card-0" />,
+    );
+    const observer = MockIntersectionObserver.instances[0];
+    const [target] = observer.observed;
+
+    act(() => {
+      observer.callback([{ target, isIntersecting: false }]);
+    });
+
+    expect(queryByTestId("card-0-name")).not.toBeInTheDocument();
+  });
+
+  it("should disconnect the observer on unmount", () => {
+    const { unmount } = render(<LazyCatalogCard item={item} testId="card-0" />);
+    const observer = MockIntersectionObserver.instances[0];
+    const disconnectSpy = jest.spyOn(observer, "disconnect");
+    unmount();
+    expect(disconnectSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/__tests__/__snapshots__/DrawerMenu.tests.js.snap
+++ b/src/components/__tests__/__snapshots__/DrawerMenu.tests.js.snap
@@ -51,6 +51,23 @@ exports[`DrawerMenu should render correctly 1`] = `
             All Items
           </a>
           <a
+            aria-controls="dynamic_catalog_submenu"
+            aria-expanded="false"
+            class="bm-item menu-item"
+            data-test="dynamic-catalog-sidebar-link"
+            href="#"
+            id="dynamic_catalog_sidebar_link"
+            role="button"
+            style="display: block;"
+            tabindex="-1"
+          >
+            Dynamic Catalog
+            <span
+              aria-hidden="true"
+              class="submenu-chevron"
+            />
+          </a>
+          <a
             class="bm-item menu-item"
             data-test="about-sidebar-link"
             href="https://saucelabs.com/"
@@ -161,6 +178,23 @@ exports[`DrawerMenu should render correctly for a visual user 1`] = `
             tabindex="-1"
           >
             All Items
+          </a>
+          <a
+            aria-controls="dynamic_catalog_submenu"
+            aria-expanded="false"
+            class="bm-item menu-item"
+            data-test="dynamic-catalog-sidebar-link"
+            href="#"
+            id="dynamic_catalog_sidebar_link"
+            role="button"
+            style="display: block;"
+            tabindex="-1"
+          >
+            Dynamic Catalog
+            <span
+              aria-hidden="true"
+              class="submenu-chevron"
+            />
           </a>
           <a
             class="bm-item menu-item"

--- a/src/components/__tests__/__snapshots__/HeaderContainer.tests.js.snap
+++ b/src/components/__tests__/__snapshots__/HeaderContainer.tests.js.snap
@@ -63,6 +63,23 @@ exports[`HeaderContainer should render for a visual user 1`] = `
                   All Items
                 </a>
                 <a
+                  aria-controls="dynamic_catalog_submenu"
+                  aria-expanded="false"
+                  class="bm-item menu-item"
+                  data-test="dynamic-catalog-sidebar-link"
+                  href="#"
+                  id="dynamic_catalog_sidebar_link"
+                  role="button"
+                  style="display: block;"
+                  tabindex="-1"
+                >
+                  Dynamic Catalog
+                  <span
+                    aria-hidden="true"
+                    class="submenu-chevron"
+                  />
+                </a>
+                <a
                   class="bm-item menu-item"
                   data-test="about-sidebar-link"
                   href="https://saucelabs.com/"
@@ -212,6 +229,23 @@ exports[`HeaderContainer should render with all props 1`] = `
                   tabindex="-1"
                 >
                   All Items
+                </a>
+                <a
+                  aria-controls="dynamic_catalog_submenu"
+                  aria-expanded="false"
+                  class="bm-item menu-item"
+                  data-test="dynamic-catalog-sidebar-link"
+                  href="#"
+                  id="dynamic_catalog_sidebar_link"
+                  role="button"
+                  style="display: block;"
+                  tabindex="-1"
+                >
+                  Dynamic Catalog
+                  <span
+                    aria-hidden="true"
+                    class="submenu-chevron"
+                  />
                 </a>
                 <a
                   class="bm-item menu-item"
@@ -384,6 +418,23 @@ exports[`HeaderContainer should render without any props 1`] = `
                   tabindex="-1"
                 >
                   All Items
+                </a>
+                <a
+                  aria-controls="dynamic_catalog_submenu"
+                  aria-expanded="false"
+                  class="bm-item menu-item"
+                  data-test="dynamic-catalog-sidebar-link"
+                  href="#"
+                  id="dynamic_catalog_sidebar_link"
+                  role="button"
+                  style="display: block;"
+                  tabindex="-1"
+                >
+                  Dynamic Catalog
+                  <span
+                    aria-hidden="true"
+                    class="submenu-chevron"
+                  />
                 </a>
                 <a
                   class="bm-item menu-item"

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -7,6 +7,9 @@ import "./index.css";
 import Cart from "./pages/Cart";
 import CheckOutStepOne from "./pages/CheckOutStepOne";
 import CheckOutStepTwo from "./pages/CheckOutStepTwo";
+import DynamicCatalogLazyLoad from "./pages/DynamicCatalogLazyLoad";
+import DynamicCatalogSlider from "./pages/DynamicCatalogSlider";
+import DynamicCatalogSpinner from "./pages/DynamicCatalogSpinner";
 import Finish from "./pages/Finish";
 import Inventory from "./pages/Inventory";
 import InventoryItem from "./pages/InventoryItem";
@@ -67,6 +70,18 @@ const routing = (
         <Route
           path={ROUTES.CHECKOUT_COMPLETE}
           element={<PrivateRoute component={Finish} />}
+        />
+        <Route
+          path={ROUTES.DYNAMIC_CATALOG_LAZY_LOAD}
+          element={<PrivateRoute component={DynamicCatalogLazyLoad} />}
+        />
+        <Route
+          path={ROUTES.DYNAMIC_CATALOG_SPINNER}
+          element={<PrivateRoute component={DynamicCatalogSpinner} />}
+        />
+        <Route
+          path={ROUTES.DYNAMIC_CATALOG_SLIDER}
+          element={<PrivateRoute component={DynamicCatalogSlider} />}
         />
       </Routes>
     </Router>

--- a/src/pages/DynamicCatalogLazyLoad.css
+++ b/src/pages/DynamicCatalogLazyLoad.css
@@ -1,0 +1,12 @@
+.dynamic_catalog_lazy_load_container {
+  max-width: 1060px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 20px;
+  padding: 40px 15px 60px;
+}
+
+.dynamic_catalog_lazy_load_sentinel {
+  height: 1px;
+}

--- a/src/pages/DynamicCatalogLazyLoad.jsx
+++ b/src/pages/DynamicCatalogLazyLoad.jsx
@@ -1,0 +1,64 @@
+import React, { useEffect, useRef, useState } from "react";
+import HeaderContainer from "../components/HeaderContainer";
+import SwagLabsFooter from "../components/Footer";
+import LazyCatalogCard from "../components/LazyCatalogCard";
+import { InventoryDataLong } from "../utils/InventoryDataLong";
+import "./DynamicCatalogLazyLoad.css";
+
+export const INITIAL_VISIBLE_COUNT = 6;
+export const LOAD_MORE_BATCH_SIZE = 6;
+
+const DynamicCatalogLazyLoad = () => {
+  const [visibleCount, setVisibleCount] = useState(INITIAL_VISIBLE_COUNT);
+  const sentinelRef = useRef(null);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            setVisibleCount((current) => current + LOAD_MORE_BATCH_SIZE);
+          }
+        });
+      },
+      { threshold: 0.1 },
+    );
+
+    observer.observe(sentinelRef.current);
+
+    return () => observer.disconnect();
+  }, [visibleCount]);
+
+  const visibleItems = Array.from({ length: visibleCount }, (_, index) => ({
+    ...InventoryDataLong[index % InventoryDataLong.length],
+    index,
+  }));
+
+  return (
+    <div id="page_wrapper" className="page_wrapper">
+      <div id="contents_wrapper">
+        <HeaderContainer secondaryTitle="Dynamic Catalog - Lazy Load" />
+        <div
+          className="dynamic_catalog_lazy_load_container"
+          data-test="dynamic-catalog-lazy-load-container"
+        >
+          {visibleItems.map((item) => (
+            <LazyCatalogCard
+              key={item.index}
+              item={item}
+              testId={`lazy-load-item-${item.index}`}
+            />
+          ))}
+        </div>
+        <div
+          ref={sentinelRef}
+          className="dynamic_catalog_lazy_load_sentinel"
+          data-test="dynamic-catalog-lazy-load-sentinel"
+        />
+      </div>
+      <SwagLabsFooter />
+    </div>
+  );
+};
+
+export default DynamicCatalogLazyLoad;

--- a/src/pages/DynamicCatalogSlider.css
+++ b/src/pages/DynamicCatalogSlider.css
@@ -1,0 +1,29 @@
+.dynamic_catalog_slider_container {
+  max-width: 400px;
+  margin: 0 auto;
+  padding: 40px 15px 60px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.dynamic_catalog_slider_dots {
+  display: flex;
+  gap: 10px;
+  margin-top: 20px;
+}
+
+.dynamic_catalog_slider_dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  border: 1px solid #767676;
+  background: #fff;
+  padding: 0;
+  cursor: pointer;
+}
+
+.dynamic_catalog_slider_dot.active {
+  background: #3ddc91;
+  border-color: #3ddc91;
+}

--- a/src/pages/DynamicCatalogSlider.jsx
+++ b/src/pages/DynamicCatalogSlider.jsx
@@ -1,0 +1,60 @@
+import React, { useEffect, useState } from "react";
+import HeaderContainer from "../components/HeaderContainer";
+import SwagLabsFooter from "../components/Footer";
+import DynamicCatalogItemCard from "../components/DynamicCatalogItemCard";
+import { InventoryData } from "../utils/InventoryData";
+import "./DynamicCatalogSlider.css";
+
+export const SLIDER_INTERVAL_MS = 2000;
+
+const DynamicCatalogSlider = () => {
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setActiveIndex((current) => (current + 1) % InventoryData.length);
+    }, SLIDER_INTERVAL_MS);
+
+    return () => clearInterval(timer);
+  }, []);
+
+  const activeItem = InventoryData[activeIndex];
+
+  return (
+    <div id="page_wrapper" className="page_wrapper">
+      <div id="contents_wrapper">
+        <HeaderContainer secondaryTitle="Dynamic Catalog - Slider" />
+        <div
+          className="dynamic_catalog_slider_container"
+          data-test="dynamic-catalog-slider-container"
+        >
+          <DynamicCatalogItemCard
+            item={activeItem}
+            testId="dynamic-catalog-slider-item"
+          />
+          <div
+            className="dynamic_catalog_slider_dots"
+            data-test="dynamic-catalog-slider-dots"
+          >
+            {InventoryData.map((item, index) => (
+              <button
+                key={item.id}
+                type="button"
+                className={`dynamic_catalog_slider_dot${
+                  index === activeIndex ? " active" : ""
+                }`}
+                aria-label={`Show ${item.name}`}
+                aria-current={index === activeIndex}
+                data-test={`dynamic-catalog-slider-dot-${index}`}
+                onClick={() => setActiveIndex(index)}
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+      <SwagLabsFooter />
+    </div>
+  );
+};
+
+export default DynamicCatalogSlider;

--- a/src/pages/DynamicCatalogSpinner.css
+++ b/src/pages/DynamicCatalogSpinner.css
@@ -1,0 +1,31 @@
+.dynamic_catalog_spinner_container {
+  max-width: 1060px;
+  margin: 0 auto;
+  padding: 40px 15px 60px;
+  min-height: 260px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.dynamic_catalog_spinner {
+  width: 48px;
+  height: 48px;
+  border: 5px solid #ededed;
+  border-top-color: #3ddc91;
+  border-radius: 50%;
+  animation: dynamic_catalog_spin 0.8s linear infinite;
+}
+
+@keyframes dynamic_catalog_spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.dynamic_catalog_spinner_grid {
+  width: 100%;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 20px;
+}

--- a/src/pages/DynamicCatalogSpinner.jsx
+++ b/src/pages/DynamicCatalogSpinner.jsx
@@ -1,0 +1,65 @@
+import React, { useEffect, useState } from "react";
+import HeaderContainer from "../components/HeaderContainer";
+import SwagLabsFooter from "../components/Footer";
+import DynamicCatalogItemCard from "../components/DynamicCatalogItemCard";
+import { InventoryData } from "../utils/InventoryData";
+import "./DynamicCatalogSpinner.css";
+
+export const MIN_SPINNER_DELAY_MS = 500;
+export const MAX_SPINNER_DELAY_MS = 3000;
+
+export function getRandomSpinnerDelay() {
+  return (
+    MIN_SPINNER_DELAY_MS +
+    Math.random() * (MAX_SPINNER_DELAY_MS - MIN_SPINNER_DELAY_MS)
+  );
+}
+
+const DynamicCatalogSpinner = () => {
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setIsLoading(false);
+    }, getRandomSpinnerDelay());
+
+    return () => clearTimeout(timer);
+  }, []);
+
+  return (
+    <div id="page_wrapper" className="page_wrapper">
+      <div id="contents_wrapper">
+        <HeaderContainer secondaryTitle="Dynamic Catalog - Spinner" />
+        <div
+          className="dynamic_catalog_spinner_container"
+          data-test="dynamic-catalog-spinner-container"
+        >
+          {isLoading ? (
+            <div
+              className="dynamic_catalog_spinner"
+              data-test="dynamic-catalog-spinner"
+              role="status"
+              aria-label="Loading"
+            />
+          ) : (
+            <div
+              className="dynamic_catalog_spinner_grid"
+              data-test="dynamic-catalog-spinner-grid"
+            >
+              {InventoryData.map((item) => (
+                <DynamicCatalogItemCard
+                  key={item.id}
+                  item={item}
+                  testId={`spinner-item-${item.id}`}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+      <SwagLabsFooter />
+    </div>
+  );
+};
+
+export default DynamicCatalogSpinner;

--- a/src/pages/__tests__/DynamicCatalogLazyLoad.tests.js
+++ b/src/pages/__tests__/DynamicCatalogLazyLoad.tests.js
@@ -1,0 +1,144 @@
+import React from "react";
+import { act, render } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import DynamicCatalogLazyLoad, {
+  INITIAL_VISIBLE_COUNT,
+  LOAD_MORE_BATCH_SIZE,
+} from "../DynamicCatalogLazyLoad";
+
+class MockIntersectionObserver {
+  constructor(callback) {
+    this.callback = callback;
+    this.observed = [];
+    MockIntersectionObserver.instances.push(this);
+  }
+
+  observe(target) {
+    this.observed.push(target);
+  }
+
+  unobserve(target) {
+    this.observed = this.observed.filter((node) => node !== target);
+  }
+
+  disconnect() {
+    this.observed = [];
+  }
+}
+MockIntersectionObserver.instances = [];
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <DynamicCatalogLazyLoad />
+    </MemoryRouter>,
+  );
+}
+
+function findSentinelObserver() {
+  return MockIntersectionObserver.instances.find(
+    (instance) =>
+      instance.observed[0]?.dataset.test ===
+      "dynamic-catalog-lazy-load-sentinel",
+  );
+}
+
+function triggerSentinelIntersection() {
+  const observer = findSentinelObserver();
+  const [sentinel] = observer.observed;
+  act(() => {
+    observer.callback([{ target: sentinel, isIntersecting: true }]);
+  });
+}
+
+describe("DynamicCatalogLazyLoad", () => {
+  const realIntersectionObserver = global.IntersectionObserver;
+
+  beforeEach(() => {
+    MockIntersectionObserver.instances = [];
+    global.IntersectionObserver = MockIntersectionObserver;
+  });
+
+  afterEach(() => {
+    global.IntersectionObserver = realIntersectionObserver;
+  });
+
+  it("should render correctly", () => {
+    const { asFragment } = renderPage();
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it("should render only the initial batch of items", () => {
+    const { getByTestId, queryByTestId } = renderPage();
+    for (let i = 0; i < INITIAL_VISIBLE_COUNT; i++) {
+      expect(
+        getByTestId(`lazy-load-item-${i}-placeholder`),
+      ).toBeInTheDocument();
+    }
+    expect(
+      queryByTestId(`lazy-load-item-${INITIAL_VISIBLE_COUNT}-placeholder`),
+    ).not.toBeInTheDocument();
+  });
+
+  it("should load another batch once the sentinel scrolls into view", () => {
+    const { getByTestId } = renderPage();
+
+    triggerSentinelIntersection();
+
+    const lastNewIndex = INITIAL_VISIBLE_COUNT + LOAD_MORE_BATCH_SIZE - 1;
+    expect(
+      getByTestId(`lazy-load-item-${lastNewIndex}-placeholder`),
+    ).toBeInTheDocument();
+  });
+
+  it("should re-arm detection with a fresh observer after each batch, so a still-visible sentinel keeps loading", () => {
+    const { getByTestId } = renderPage();
+    const firstObserver = findSentinelObserver();
+
+    triggerSentinelIntersection();
+
+    const secondObserver = findSentinelObserver();
+    expect(secondObserver).not.toBe(firstObserver);
+    expect(firstObserver.observed).toHaveLength(0);
+
+    const lastNewIndex = INITIAL_VISIBLE_COUNT + LOAD_MORE_BATCH_SIZE - 1;
+    expect(
+      getByTestId(`lazy-load-item-${lastNewIndex}-placeholder`),
+    ).toBeInTheDocument();
+  });
+
+  it("should keep loading more batches across repeated scrolls, cycling the catalog data", () => {
+    const { getByTestId } = renderPage();
+
+    triggerSentinelIntersection();
+    triggerSentinelIntersection();
+    triggerSentinelIntersection();
+
+    const lastIndex = INITIAL_VISIBLE_COUNT + LOAD_MORE_BATCH_SIZE * 3 - 1;
+    expect(
+      getByTestId(`lazy-load-item-${lastIndex}-placeholder`),
+    ).toBeInTheDocument();
+  });
+
+  it("should ignore sentinel entries that are not intersecting", () => {
+    const { queryByTestId } = renderPage();
+    const observer = findSentinelObserver();
+    const [sentinel] = observer.observed;
+
+    act(() => {
+      observer.callback([{ target: sentinel, isIntersecting: false }]);
+    });
+
+    expect(
+      queryByTestId(`lazy-load-item-${INITIAL_VISIBLE_COUNT}-placeholder`),
+    ).not.toBeInTheDocument();
+  });
+
+  it("should disconnect the sentinel observer on unmount", () => {
+    const { unmount } = renderPage();
+    const observer = findSentinelObserver();
+    const disconnectSpy = jest.spyOn(observer, "disconnect");
+    unmount();
+    expect(disconnectSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/pages/__tests__/DynamicCatalogSlider.tests.js
+++ b/src/pages/__tests__/DynamicCatalogSlider.tests.js
@@ -1,0 +1,82 @@
+import React from "react";
+import { act, fireEvent, render } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import DynamicCatalogSlider, {
+  SLIDER_INTERVAL_MS,
+} from "../DynamicCatalogSlider";
+import { InventoryData } from "../../utils/InventoryData";
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <DynamicCatalogSlider />
+    </MemoryRouter>,
+  );
+}
+
+describe("DynamicCatalogSlider", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("should show the first item initially", () => {
+    const { getByTestId } = renderPage();
+    expect(getByTestId("dynamic-catalog-slider-item-name")).toHaveTextContent(
+      InventoryData[0].name,
+    );
+    expect(getByTestId("dynamic-catalog-slider-dot-0")).toHaveClass("active");
+  });
+
+  it("should advance to the next item automatically", () => {
+    const { getByTestId } = renderPage();
+
+    act(() => {
+      jest.advanceTimersByTime(SLIDER_INTERVAL_MS);
+    });
+
+    expect(getByTestId("dynamic-catalog-slider-item-name")).toHaveTextContent(
+      InventoryData[1].name,
+    );
+    expect(getByTestId("dynamic-catalog-slider-dot-1")).toHaveClass("active");
+  });
+
+  it("should wrap around to the first item after the last one", () => {
+    const { getByTestId } = renderPage();
+
+    act(() => {
+      jest.advanceTimersByTime(SLIDER_INTERVAL_MS * InventoryData.length);
+    });
+
+    expect(getByTestId("dynamic-catalog-slider-item-name")).toHaveTextContent(
+      InventoryData[0].name,
+    );
+  });
+
+  it("should jump to an item when its dot is clicked", () => {
+    const { getByTestId } = renderPage();
+
+    fireEvent.click(getByTestId("dynamic-catalog-slider-dot-3"));
+
+    expect(getByTestId("dynamic-catalog-slider-item-name")).toHaveTextContent(
+      InventoryData[3].name,
+    );
+    expect(getByTestId("dynamic-catalog-slider-dot-3")).toHaveClass("active");
+    expect(getByTestId("dynamic-catalog-slider-dot-0")).not.toHaveClass(
+      "active",
+    );
+  });
+
+  it("should stop advancing after unmount", () => {
+    const { unmount } = renderPage();
+    unmount();
+    expect(() => {
+      act(() => {
+        jest.advanceTimersByTime(SLIDER_INTERVAL_MS);
+      });
+    }).not.toThrow();
+  });
+});

--- a/src/pages/__tests__/DynamicCatalogSpinner.tests.js
+++ b/src/pages/__tests__/DynamicCatalogSpinner.tests.js
@@ -1,0 +1,56 @@
+import React from "react";
+import { act, render } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import DynamicCatalogSpinner, {
+  MAX_SPINNER_DELAY_MS,
+  MIN_SPINNER_DELAY_MS,
+  getRandomSpinnerDelay,
+} from "../DynamicCatalogSpinner";
+import { InventoryData } from "../../utils/InventoryData";
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <DynamicCatalogSpinner />
+    </MemoryRouter>,
+  );
+}
+
+describe("DynamicCatalogSpinner", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("should show a spinner while loading", () => {
+    const { getByTestId, queryByTestId } = renderPage();
+    expect(getByTestId("dynamic-catalog-spinner")).toBeInTheDocument();
+    expect(
+      queryByTestId("dynamic-catalog-spinner-grid"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("should render every item once the loading delay elapses", () => {
+    const { getByTestId, queryByTestId } = renderPage();
+
+    act(() => {
+      jest.advanceTimersByTime(MAX_SPINNER_DELAY_MS);
+    });
+
+    expect(queryByTestId("dynamic-catalog-spinner")).not.toBeInTheDocument();
+    InventoryData.forEach((item) => {
+      expect(getByTestId(`spinner-item-${item.id}-name`)).toBeInTheDocument();
+    });
+  });
+
+  it("should generate a random delay within the expected bounds", () => {
+    for (let i = 0; i < 20; i++) {
+      const delay = getRandomSpinnerDelay();
+      expect(delay).toBeGreaterThanOrEqual(MIN_SPINNER_DELAY_MS);
+      expect(delay).toBeLessThanOrEqual(MAX_SPINNER_DELAY_MS);
+    }
+  });
+});

--- a/src/pages/__tests__/__snapshots__/Cart.tests.js.snap
+++ b/src/pages/__tests__/__snapshots__/Cart.tests.js.snap
@@ -70,6 +70,23 @@ exports[`Cart should render correctly for a visual user 1`] = `
                       All Items
                     </a>
                     <a
+                      aria-controls="dynamic_catalog_submenu"
+                      aria-expanded="false"
+                      class="bm-item menu-item"
+                      data-test="dynamic-catalog-sidebar-link"
+                      href="#"
+                      id="dynamic_catalog_sidebar_link"
+                      role="button"
+                      style="display: block;"
+                      tabindex="-1"
+                    >
+                      Dynamic Catalog
+                      <span
+                        aria-hidden="true"
+                        class="submenu-chevron"
+                      />
+                    </a>
+                    <a
                       class="bm-item menu-item"
                       data-test="about-sidebar-link"
                       href="https://saucelabs.com/"
@@ -337,6 +354,23 @@ exports[`Cart should render correctly items 1`] = `
                       tabindex="-1"
                     >
                       All Items
+                    </a>
+                    <a
+                      aria-controls="dynamic_catalog_submenu"
+                      aria-expanded="false"
+                      class="bm-item menu-item"
+                      data-test="dynamic-catalog-sidebar-link"
+                      href="#"
+                      id="dynamic_catalog_sidebar_link"
+                      role="button"
+                      style="display: block;"
+                      tabindex="-1"
+                    >
+                      Dynamic Catalog
+                      <span
+                        aria-hidden="true"
+                        class="submenu-chevron"
+                      />
                     </a>
                     <a
                       class="bm-item menu-item"
@@ -772,6 +806,23 @@ exports[`Cart should render correctly without any items 1`] = `
                       tabindex="-1"
                     >
                       All Items
+                    </a>
+                    <a
+                      aria-controls="dynamic_catalog_submenu"
+                      aria-expanded="false"
+                      class="bm-item menu-item"
+                      data-test="dynamic-catalog-sidebar-link"
+                      href="#"
+                      id="dynamic_catalog_sidebar_link"
+                      role="button"
+                      style="display: block;"
+                      tabindex="-1"
+                    >
+                      Dynamic Catalog
+                      <span
+                        aria-hidden="true"
+                        class="submenu-chevron"
+                      />
                     </a>
                     <a
                       class="bm-item menu-item"

--- a/src/pages/__tests__/__snapshots__/CheckOutStepTwo.tests.js.snap
+++ b/src/pages/__tests__/__snapshots__/CheckOutStepTwo.tests.js.snap
@@ -70,6 +70,23 @@ exports[`CheckOutStepTwo should give the incorrect order total when we are logge
                       All Items
                     </a>
                     <a
+                      aria-controls="dynamic_catalog_submenu"
+                      aria-expanded="false"
+                      class="bm-item menu-item"
+                      data-test="dynamic-catalog-sidebar-link"
+                      href="#"
+                      id="dynamic_catalog_sidebar_link"
+                      role="button"
+                      style="display: block;"
+                      tabindex="-1"
+                    >
+                      Dynamic Catalog
+                      <span
+                        aria-hidden="true"
+                        class="submenu-chevron"
+                      />
+                    </a>
+                    <a
                       class="bm-item menu-item"
                       data-test="about-sidebar-link"
                       href="https://saucelabs.com/error/404"
@@ -533,6 +550,23 @@ exports[`CheckOutStepTwo should render correctly items 1`] = `
                       All Items
                     </a>
                     <a
+                      aria-controls="dynamic_catalog_submenu"
+                      aria-expanded="false"
+                      class="bm-item menu-item"
+                      data-test="dynamic-catalog-sidebar-link"
+                      href="#"
+                      id="dynamic_catalog_sidebar_link"
+                      role="button"
+                      style="display: block;"
+                      tabindex="-1"
+                    >
+                      Dynamic Catalog
+                      <span
+                        aria-hidden="true"
+                        class="submenu-chevron"
+                      />
+                    </a>
+                    <a
                       class="bm-item menu-item"
                       data-test="about-sidebar-link"
                       href="https://saucelabs.com/"
@@ -994,6 +1028,23 @@ exports[`CheckOutStepTwo should render correctly without any items 1`] = `
                       tabindex="-1"
                     >
                       All Items
+                    </a>
+                    <a
+                      aria-controls="dynamic_catalog_submenu"
+                      aria-expanded="false"
+                      class="bm-item menu-item"
+                      data-test="dynamic-catalog-sidebar-link"
+                      href="#"
+                      id="dynamic_catalog_sidebar_link"
+                      role="button"
+                      style="display: block;"
+                      tabindex="-1"
+                    >
+                      Dynamic Catalog
+                      <span
+                        aria-hidden="true"
+                        class="submenu-chevron"
+                      />
                     </a>
                     <a
                       class="bm-item menu-item"

--- a/src/pages/__tests__/__snapshots__/DynamicCatalogLazyLoad.tests.js.snap
+++ b/src/pages/__tests__/__snapshots__/DynamicCatalogLazyLoad.tests.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`CheckOutStepOne should render correctly 1`] = `
+exports[`DynamicCatalogLazyLoad should render correctly 1`] = `
 <DocumentFragment>
   <div
     class="page_wrapper"
@@ -175,105 +175,85 @@ exports[`CheckOutStepOne should render correctly 1`] = `
             class="title"
             data-test="title"
           >
-            Checkout: Your Information
+            Dynamic Catalog - Lazy Load
           </span>
         </div>
       </header>
       <div
-        class="checkout_info_container"
-        data-test="checkout-info-container"
-        id="checkout_info_container"
-        role="main"
+        class="dynamic_catalog_lazy_load_container"
+        data-test="dynamic-catalog-lazy-load-container"
       >
         <div
-          class="checkout_info_wrapper"
+          class="dynamic_catalog_card"
+          data-test="lazy-load-item-0"
         >
-          <form
-            aria-label="Checkout information"
+          <div
+            class="dynamic_catalog_card_placeholder"
+            data-test="lazy-load-item-0-placeholder"
           >
-            <div
-              class="checkout_info"
-            >
-              <div
-                class="form_group"
-              >
-                <input
-                  aria-label="First Name"
-                  autocapitalize="none"
-                  autocorrect="off"
-                  class="input_error form_input"
-                  data-test="firstName"
-                  id="first-name"
-                  name="firstName"
-                  placeholder="First Name"
-                  type="text"
-                  value=""
-                />
-              </div>
-              <div
-                class="form_group"
-              >
-                <input
-                  aria-label="Last Name"
-                  autocapitalize="none"
-                  autocorrect="off"
-                  class="input_error form_input"
-                  data-test="lastName"
-                  id="last-name"
-                  name="lastName"
-                  placeholder="Last Name"
-                  type="text"
-                  value=""
-                />
-              </div>
-              <div
-                class="form_group"
-              >
-                <input
-                  aria-label="Zip/Postal Code"
-                  autocapitalize="none"
-                  autocorrect="off"
-                  class="input_error form_input"
-                  data-test="postalCode"
-                  id="postal-code"
-                  name="postalCode"
-                  placeholder="Zip/Postal Code"
-                  type="text"
-                  value=""
-                />
-              </div>
-              <div
-                class="error-message-container"
-              />
-            </div>
-            <div
-              class="checkout_buttons"
-            >
-              <button
-                class="btn btn_secondary back btn_medium cart_cancel_link"
-                data-test="cancel"
-                id="cancel"
-                name="cancel"
-              >
-                <img
-                  alt=""
-                  class="back-image"
-                  src="test-file-stub"
-                />
-                Cancel
-              </button>
-              <input
-                class="submit-button btn btn_primary cart_button btn_action"
-                data-test="continue"
-                id="continue"
-                name="continue"
-                type="submit"
-                value="Continue"
-              />
-            </div>
-          </form>
+            Loading…
+          </div>
+        </div>
+        <div
+          class="dynamic_catalog_card"
+          data-test="lazy-load-item-1"
+        >
+          <div
+            class="dynamic_catalog_card_placeholder"
+            data-test="lazy-load-item-1-placeholder"
+          >
+            Loading…
+          </div>
+        </div>
+        <div
+          class="dynamic_catalog_card"
+          data-test="lazy-load-item-2"
+        >
+          <div
+            class="dynamic_catalog_card_placeholder"
+            data-test="lazy-load-item-2-placeholder"
+          >
+            Loading…
+          </div>
+        </div>
+        <div
+          class="dynamic_catalog_card"
+          data-test="lazy-load-item-3"
+        >
+          <div
+            class="dynamic_catalog_card_placeholder"
+            data-test="lazy-load-item-3-placeholder"
+          >
+            Loading…
+          </div>
+        </div>
+        <div
+          class="dynamic_catalog_card"
+          data-test="lazy-load-item-4"
+        >
+          <div
+            class="dynamic_catalog_card_placeholder"
+            data-test="lazy-load-item-4-placeholder"
+          >
+            Loading…
+          </div>
+        </div>
+        <div
+          class="dynamic_catalog_card"
+          data-test="lazy-load-item-5"
+        >
+          <div
+            class="dynamic_catalog_card_placeholder"
+            data-test="lazy-load-item-5-placeholder"
+          >
+            Loading…
+          </div>
         </div>
       </div>
+      <div
+        class="dynamic_catalog_lazy_load_sentinel"
+        data-test="dynamic-catalog-lazy-load-sentinel"
+      />
     </div>
     <footer
       class="footer"

--- a/src/pages/__tests__/__snapshots__/Finish.tests.js.snap
+++ b/src/pages/__tests__/__snapshots__/Finish.tests.js.snap
@@ -70,6 +70,23 @@ exports[`CheckOutStepTwo should render correctly with default props 1`] = `
                       All Items
                     </a>
                     <a
+                      aria-controls="dynamic_catalog_submenu"
+                      aria-expanded="false"
+                      class="bm-item menu-item"
+                      data-test="dynamic-catalog-sidebar-link"
+                      href="#"
+                      id="dynamic_catalog_sidebar_link"
+                      role="button"
+                      style="display: block;"
+                      tabindex="-1"
+                    >
+                      Dynamic Catalog
+                      <span
+                        aria-hidden="true"
+                        class="submenu-chevron"
+                      />
+                    </a>
+                    <a
                       class="bm-item menu-item"
                       data-test="about-sidebar-link"
                       href="https://saucelabs.com/"

--- a/src/pages/__tests__/__snapshots__/Inventory.tests.js.snap
+++ b/src/pages/__tests__/__snapshots__/Inventory.tests.js.snap
@@ -70,6 +70,23 @@ exports[`Inventory should render correctly 1`] = `
                       All Items
                     </a>
                     <a
+                      aria-controls="dynamic_catalog_submenu"
+                      aria-expanded="false"
+                      class="bm-item menu-item"
+                      data-test="dynamic-catalog-sidebar-link"
+                      href="#"
+                      id="dynamic_catalog_sidebar_link"
+                      role="button"
+                      style="display: block;"
+                      tabindex="-1"
+                    >
+                      Dynamic Catalog
+                      <span
+                        aria-hidden="true"
+                        class="submenu-chevron"
+                      />
+                    </a>
+                    <a
                       class="bm-item menu-item"
                       data-test="about-sidebar-link"
                       href="https://saucelabs.com/"
@@ -760,6 +777,23 @@ exports[`Inventory should render correctly for a problem user 1`] = `
                       All Items
                     </a>
                     <a
+                      aria-controls="dynamic_catalog_submenu"
+                      aria-expanded="false"
+                      class="bm-item menu-item"
+                      data-test="dynamic-catalog-sidebar-link"
+                      href="#"
+                      id="dynamic_catalog_sidebar_link"
+                      role="button"
+                      style="display: block;"
+                      tabindex="-1"
+                    >
+                      Dynamic Catalog
+                      <span
+                        aria-hidden="true"
+                        class="submenu-chevron"
+                      />
+                    </a>
+                    <a
                       class="bm-item menu-item"
                       data-test="about-sidebar-link"
                       href="https://saucelabs.com/error/404"
@@ -1448,6 +1482,23 @@ exports[`Inventory should render correctly for a visual user 1`] = `
                       tabindex="-1"
                     >
                       All Items
+                    </a>
+                    <a
+                      aria-controls="dynamic_catalog_submenu"
+                      aria-expanded="false"
+                      class="bm-item menu-item"
+                      data-test="dynamic-catalog-sidebar-link"
+                      href="#"
+                      id="dynamic_catalog_sidebar_link"
+                      role="button"
+                      style="display: block;"
+                      tabindex="-1"
+                    >
+                      Dynamic Catalog
+                      <span
+                        aria-hidden="true"
+                        class="submenu-chevron"
+                      />
                     </a>
                     <a
                       class="bm-item menu-item"

--- a/src/pages/__tests__/__snapshots__/InventoryItem.tests.js.snap
+++ b/src/pages/__tests__/__snapshots__/InventoryItem.tests.js.snap
@@ -69,6 +69,23 @@ exports[`InventoryItem should render with BrokenComponent for an error user 1`] 
                       All Items
                     </a>
                     <a
+                      aria-controls="dynamic_catalog_submenu"
+                      aria-expanded="false"
+                      class="bm-item menu-item"
+                      data-test="dynamic-catalog-sidebar-link"
+                      href="#"
+                      id="dynamic_catalog_sidebar_link"
+                      role="button"
+                      style="display: block;"
+                      tabindex="-1"
+                    >
+                      Dynamic Catalog
+                      <span
+                        aria-hidden="true"
+                        class="submenu-chevron"
+                      />
+                    </a>
+                    <a
                       class="bm-item menu-item"
                       data-test="about-sidebar-link"
                       href="https://saucelabs.com/"
@@ -352,6 +369,23 @@ exports[`InventoryItem should render with default props 1`] = `
                       All Items
                     </a>
                     <a
+                      aria-controls="dynamic_catalog_submenu"
+                      aria-expanded="false"
+                      class="bm-item menu-item"
+                      data-test="dynamic-catalog-sidebar-link"
+                      href="#"
+                      id="dynamic_catalog_sidebar_link"
+                      role="button"
+                      style="display: block;"
+                      tabindex="-1"
+                    >
+                      Dynamic Catalog
+                      <span
+                        aria-hidden="true"
+                        class="submenu-chevron"
+                      />
+                    </a>
+                    <a
                       class="bm-item menu-item"
                       data-test="about-sidebar-link"
                       href="https://saucelabs.com/"
@@ -633,6 +667,23 @@ exports[`InventoryItem should render with error data if a not known product is o
                       tabindex="-1"
                     >
                       All Items
+                    </a>
+                    <a
+                      aria-controls="dynamic_catalog_submenu"
+                      aria-expanded="false"
+                      class="bm-item menu-item"
+                      data-test="dynamic-catalog-sidebar-link"
+                      href="#"
+                      id="dynamic_catalog_sidebar_link"
+                      role="button"
+                      style="display: block;"
+                      tabindex="-1"
+                    >
+                      Dynamic Catalog
+                      <span
+                        aria-hidden="true"
+                        class="submenu-chevron"
+                      />
                     </a>
                     <a
                       class="bm-item menu-item"

--- a/src/utils/Constants.js
+++ b/src/utils/Constants.js
@@ -17,6 +17,9 @@ export const ROUTES = {
   CHECKOUT_STEP_ONE: "/checkout-step-one.html",
   CHECKOUT_STEP_TWO: "/checkout-step-two.html",
   CHECKOUT_COMPLETE: "/checkout-complete.html",
+  DYNAMIC_CATALOG_LAZY_LOAD: "/dynamic-catalog-lazy-load.html",
+  DYNAMIC_CATALOG_SPINNER: "/dynamic-catalog-spinner.html",
+  DYNAMIC_CATALOG_SLIDER: "/dynamic-catalog-slider.html",
 };
 export const CART_CONTENTS = "cart-contents";
 export const SESSION_USERNAME = "session-username";


### PR DESCRIPTION
# One-line summary

> Issue : Fixes #32

## Description
Adds a "Dynamic Catalog" submenu to the hamburger menu, as proposed in the issue's comments, with three new demo pages that reproduce common visual-testing pitfalls customers have reported:

- **Lazy Load** (`/dynamic-catalog-lazy-load.html`): infinite-scroll style loading — starts with a handful of items and loads another batch (cycling through the catalog indefinitely) each time a sentinel element at the bottom scrolls into view. Each card also reveals its own content only once it individually scrolls into view.
- **Spinner** (`/dynamic-catalog-spinner.html`): shows a loading spinner for a randomized 0.5–3s delay before the product grid renders, forcing a snapshot race.
- **Slider** (`/dynamic-catalog-slider.html`): auto-advances through products every 2 seconds (with clickable dots), so the view never stays stable long enough for a naive snapshot.

`react-burger-menu` has no built-in submenu support, so the "Dynamic Catalog" menu item is a small custom expand/collapse toggle that reveals the three links.

## Types of Changes
_What types of changes does your code introduce? Keep the ones that apply:_

- New feature (non-breaking change which adds functionality)

## Tasks
_List of tasks you will do to complete the PR_
  - [x] Add `DYNAMIC_CATALOG_LAZY_LOAD` / `_SPINNER` / `_SLIDER` routes and wire them up in `src/index.jsx`
  - [x] Add "Dynamic Catalog" expandable submenu to `DrawerMenu.jsx`
  - [x] Build the three demo pages and shared `DynamicCatalogItemCard` / `LazyCatalogCard` components
  - [x] Add unit tests (172 tests total, 100% coverage maintained per the project's coverage threshold)

## Review
_List of tasks the reviewer must do to review the PR_
- [x] Tests
- [ ] Documentation
- [ ] CHANGELOG

## Deployment Notes
No database migrations, feature toggles, or environment changes. All new pages sit behind the existing login (`PrivateRoute`), available to any logged-in user (not gated to a specific seeded test user, since this is a testing utility rather than a simulated app defect).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fh1qkmwTQG3wHLjutWqzoG